### PR TITLE
Lower the Finder requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require": {
         "php": ">=5.4",
-        "symfony/finder": "~2.6",
+        "symfony/finder": ">=2.4",
         "voryx/thruway": "0.3.*@dev",
         "jms/serializer-bundle": "0.13.*"
     },


### PR DESCRIPTION
There is no key different between 2.4 and 2.6 that warrants the use of 2.6