### PR TITLE
use "exec" command in thruway:process; add --no-exec option to turn it off

### DIFF
--- a/src/Voryx/ThruwayBundle/Command/ThruwayProcessCommand.php
+++ b/src/Voryx/ThruwayBundle/Command/ThruwayProcessCommand.php
@@ -8,6 +8,7 @@ use Psr\Log\NullLogger;
 use React\Promise\Deferred;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Thruway\ClientSession;
@@ -61,6 +62,7 @@ class ThruwayProcessCommand extends ContainerAwareCommand
             ->setAliases(['tp'])
             ->setDescription('Thruway Process Manager')
             ->setHelp("The <info>%command.name%</info> manages thruway sub processes (workers).")
+            ->addOption('no-exec', null, InputOption::VALUE_NONE, 'Don\'t use "exec" command when starting processes')
             ->addArgument('action', InputArgument::REQUIRED, 'Actions: start, status')
             ->addArgument('worker', InputArgument::OPTIONAL, 'Actions for individual workers: start, stop, restart');
     }
@@ -273,6 +275,9 @@ class ThruwayProcessCommand extends ContainerAwareCommand
     {
 
         $phpBinary = PHP_BINARY;
+        if (!$this->input->getOption('no-exec')) {
+            $phpBinary = 'exec ' . $phpBinary;
+        }
 
         //Default Symfony Command Workers
         $defaultWorkers = [
@@ -329,6 +334,9 @@ class ThruwayProcessCommand extends ContainerAwareCommand
     protected function addWorkers($env)
     {
         $phpBinary      = PHP_BINARY;
+        if (!$this->input->getOption('no-exec')) {
+            $phpBinary = 'exec ' . $phpBinary;
+        }
         $resourceMapper = $this->getContainer()->get('voryx.thruway.resource.mapper');
         $mappings       = $resourceMapper->getAllMappings();
 


### PR DESCRIPTION
Here's an alternative solution to #56 based on the comment on #57. It uses `exec` by default, but there's a --no-exec option to turn that off if the OS doesn't support it or something.