### PR TITLE
Add escapeshellarg to PHP_BINARY

### DIFF
--- a/src/Voryx/ThruwayBundle/Command/ThruwayProcessCommand.php
+++ b/src/Voryx/ThruwayBundle/Command/ThruwayProcessCommand.php
@@ -263,7 +263,7 @@ class ThruwayProcessCommand extends ContainerAwareCommand
      */
     protected function addSymfonyCmdWorkers($env)
     {
-        $phpBinary = PHP_BINARY;
+        $phpBinary = escapeshellarg(PHP_BINARY);
         if (!$this->input->getOption('no-exec')) {
             $phpBinary = 'exec ' . $phpBinary;
         }
@@ -320,7 +320,7 @@ class ThruwayProcessCommand extends ContainerAwareCommand
      */
     protected function addWorkers($env)
     {
-        $phpBinary = PHP_BINARY;
+        $phpBinary = escapeshellarg(PHP_BINARY);
         if (!$this->input->getOption('no-exec')) {
             $phpBinary = 'exec ' . $phpBinary;
         }


### PR DESCRIPTION
Add escapeshellarg to PHP_BINARY to avoid errors in paths that contain spaces