### PR TITLE
Create a configurable match option for the Subscribe annotation.

### DIFF
--- a/src/Voryx/ThruwayBundle/Annotation/Subscribe.php
+++ b/src/Voryx/ThruwayBundle/Annotation/Subscribe.php
@@ -29,6 +29,12 @@ class Subscribe implements AnnotationInterface
     protected $worker;
 
     /**
+     * @var string $match The type of URI matcher to use: "exact" or "prefix".
+     *                    Defaults to "exact"
+     */
+    protected $match = 'exact';
+
+    /**
      * @param $options
      * @throws \InvalidArgumentException
      */
@@ -72,5 +78,21 @@ class Subscribe implements AnnotationInterface
     public function getWorker()
     {
         return $this->worker;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMatch()
+    {
+        return $this->match;
+    }
+
+    /**
+     * @param string $match
+     */
+    public function setMatch($match)
+    {
+        $this->match = $match;
     }
 }

--- a/src/Voryx/ThruwayBundle/Annotation/Subscribe.php
+++ b/src/Voryx/ThruwayBundle/Annotation/Subscribe.php
@@ -30,9 +30,8 @@ class Subscribe implements AnnotationInterface
 
     /**
      * @var string $match The type of URI matcher to use: "exact" or "prefix".
-     *                    Defaults to "exact"
      */
-    protected $match = 'exact';
+    protected $match;
 
     /**
      * @param $options

--- a/src/Voryx/ThruwayBundle/WampKernel.php
+++ b/src/Voryx/ThruwayBundle/WampKernel.php
@@ -228,14 +228,21 @@ class WampKernel implements HttpKernelInterface
      */
     protected function createSubscribe(MappingInterface $mapping)
     {
-        $topic = $mapping->getAnnotation()->getName();
+        /**
+         * @var Subscribe $annotation
+         */
+        $annotation = $mapping->getAnnotation();
+
+        $topic = $annotation->getName();
 
         $subscribeCallback = function ($args, $argsKw, $details) use ($mapping) {
             $this->handleEvent($args, $argsKw, $details, $mapping);
         };
 
         //Subscribe to a topic
-        $this->session->subscribe($topic, $subscribeCallback);
+        $this->session->subscribe($topic, $subscribeCallback, [
+            'match' => $annotation->getMatch(),
+        ]);
     }
 
     /**

--- a/src/Voryx/ThruwayBundle/WampKernel.php
+++ b/src/Voryx/ThruwayBundle/WampKernel.php
@@ -239,10 +239,14 @@ class WampKernel implements HttpKernelInterface
             $this->handleEvent($args, $argsKw, $details, $mapping);
         };
 
+        $options = [];
+
+        if ($match = $annotation->getMatch()) {
+            $options['match'] = $match;
+        }
+
         //Subscribe to a topic
-        $this->session->subscribe($topic, $subscribeCallback, [
-            'match' => $annotation->getMatch(),
-        ]);
+        $this->session->subscribe($topic, $subscribeCallback, $options);
     }
 
     /**


### PR DESCRIPTION
Fixes #78.

Feel free to merge, but I'd appreciate some help writing a test suite for it. 

This allows us to do things like ... 

``` php
class TestSubscriber
{
    /**
     * @Subscribe(value="test.output", match="prefix")
     */
    public function logTestOutput($value): void
    {
        // This would match test.output.123, test.output.blah, etc ... 
    }
}
```