### PR TITLE
Replace echo with command output

### DIFF
--- a/src/Voryx/ThruwayBundle/Command/ThruwayWorkerCommand.php
+++ b/src/Voryx/ThruwayBundle/Command/ThruwayWorkerCommand.php
@@ -53,7 +53,7 @@ class ThruwayWorkerCommand extends ContainerAwareCommand
         }
 
         try {
-            echo "Making a go at starting a Thruway worker.\n";
+            $output->write("Making a go at starting a Thruway worker.");
 
             $name             = $input->getArgument('name');
             $config           = $this->getContainer()->getParameter('voryx_thruway');


### PR DESCRIPTION
On PHP 7.2 echoing text before ini_set('session.save_path', ...) will trigger "Message:  Warning: ini_set(): Headers already sent. You cannot change the session module's ini settings at this time". Using the Symfony command output will postpone text output until all initializations are done.