### PR TITLE
Add public alias to security.user.provider.concrete.in_memory service

### DIFF
--- a/src/Voryx/ThruwayBundle/DependencyInjection/Compiler/ServiceConfigurationPass.php
+++ b/src/Voryx/ThruwayBundle/DependencyInjection/Compiler/ServiceConfigurationPass.php
@@ -17,9 +17,7 @@ class ServiceConfigurationPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-
         foreach ($container->findTaggedServiceIds('thruway.resource') as $id => $attr) {
-
             $def = $container->getDefinition($id);
 
             //For symfony >= v2.8
@@ -50,6 +48,11 @@ class ServiceConfigurationPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('thruway.internal_client') as $id => $attr) {
             $router->addMethodCall('addInternalClient', [new Reference($id)]);
+        }
+
+        if ($container->hasDefinition('security.user.provider.concrete.in_memory')) {
+            $container->addAliases(['in_memory_user_provider' => 'security.user.provider.concrete.in_memory']);
+            $container->getAlias('in_memory_user_provider')->setPublic(true);
         }
     }
 }

--- a/src/Voryx/ThruwayBundle/DependencyInjection/VoryxThruwayExtension.php
+++ b/src/Voryx/ThruwayBundle/DependencyInjection/VoryxThruwayExtension.php
@@ -81,19 +81,16 @@ class VoryxThruwayExtension extends Extension
      */
     protected function configureOptions(&$config, ContainerBuilder $container)
     {
-
         if ($config['enable_logging'] !== true) {
             Logger::set(new NullLogger());
         }
 
         if (isset($config['router']['authentication']) && $config['router']['authentication'] !== false) {
-
             //Inject the authentication manager into the router
             $container
               ->getDefinition('voryx.thruway.server')
               ->addMethodCall('registerModule', [new Reference('voryx.thruway.authentication.manager')]);
         }
-
 
         if (isset($config['router']['authorization']) && $config['router']['authorization'] !== false) {
             $authId = $config['router']['authorization'];
@@ -101,13 +98,8 @@ class VoryxThruwayExtension extends Extension
                 ->addMethodCall('registerModule', [new Reference($authId)]);
         }
 
-        if ($container->hasDefinition('security.user.provider.concrete.in_memory')) {
-            $container->addAliases(['in_memory_user_provider' => 'security.user.provider.concrete.in_memory']);
-        }
-
         //Topic State Handler
         if (isset($config['router']['enable_topic_state']) && $config['router']['enable_topic_state'] === true) {
-
             $container
               ->getDefinition('voryx.thruway.server')
               ->addMethodCall('registerModule', [new Reference('voryx.thruway.topic.state.handler')]);


### PR DESCRIPTION
We need to move definition of the `in_memory_user_provider` alias to compiller pass because `security.user.provider.concrete.in_memory` definition isn't available in the exstension.